### PR TITLE
Restore Java 11 compatibility for the binaries produced

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,8 +78,7 @@
 
         <!-- Require at least Java 17 to compile -->
         <jdk.min.version>17</jdk.min.version>
-        <maven.compiler.target>17</maven.compiler.target>
-        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.release>11</maven.compiler.release>
         <!-- maven-surefire-plugin -->
         <surefire.system.args>-Xms512m -Xmx512m</surefire.system.args>
         <skip.java8.tests>false</skip.java8.tests>


### PR DESCRIPTION
This is useful for Quarkus as we are using resteasy-spring-web but
without any Spring bits (except for API classes). All the implementation
is done by Quarkus which is still compatible with Java 11.