### PR TITLE
resteasy-spring Galleon layer and integration in WildFly Glow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest ]
         java: ['17']
-        wildfly-version: ['27.0.1.Final', '28.0.1.Final']
+        wildfly-version: ['29.0.1.Final', '30.0.0.Final']
 
     steps:
     - uses: actions/checkout@v4

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <version.org.jboss.arquillian>1.7.1.Final</version.org.jboss.arquillian>
         <version.org.testng>7.6.1</version.org.testng>
         <version.resteasy.testsuite>6.2.5.Final</version.resteasy.testsuite>
+        <version.wildfly.glow>1.0.0.Alpha7</version.wildfly.glow>
 
         <!-- Plugin Versions, please keep in alphabetical order -->
         <version.org.jboss.galleon>5.2.2.Final</version.org.jboss.galleon>

--- a/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
+++ b/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+<layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="resteasy-spring">
+    <props>
+        <!-- TODO, need to check what we need -->
+        <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/listener/listener-class,org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap"/>
+    </props>
+    <packages>
+        <package name="org.jboss.resteasy.resteasy-spring"/>
+        <package name="org.springframework.spring"/>
+        <package name="org.jboss.resteasy.resteasy-spring-web"/>
+    </packages>
+</layer-spec>
+

--- a/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
+++ b/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
@@ -5,7 +5,7 @@
     </props>
     <packages>
         <package name="org.jboss.resteasy.resteasy-spring"/>
-        <package name="org.springframework.spring"/>
+<!--        <package name="org.springframework.spring"/>-->
         <package name="org.jboss.resteasy.resteasy-spring-web"/>
     </packages>
 </layer-spec>

--- a/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
+++ b/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" ?>
 <layer-spec xmlns="urn:jboss:galleon:layer-spec:2.0" name="resteasy-spring">
     <props>
-        <!-- TODO, need to check what we need -->
         <prop name="org.wildfly.rule.xml-path" value="/WEB-INF/web.xml,/web-app/listener/listener-class,org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap"/>
     </props>
     <packages>

--- a/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
+++ b/resteasy-spring-feature-pack/common/src/main/resources/layers/standalone/resteasy-spring/layer-spec.xml
@@ -5,7 +5,7 @@
     </props>
     <packages>
         <package name="org.jboss.resteasy.resteasy-spring"/>
-<!--        <package name="org.springframework.spring"/>-->
+        <package name="org.springframework.spring"/>
         <package name="org.jboss.resteasy.resteasy-spring-web"/>
     </packages>
 </layer-spec>

--- a/resteasy-spring-test-bom/pom.xml
+++ b/resteasy-spring-test-bom/pom.xml
@@ -95,7 +95,18 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-
+            <dependency>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-core</artifactId>
+                <scope>test</scope>
+                <version>${version.wildfly.glow}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wildfly.glow</groupId>
+                <artifactId>wildfly-glow-maven-resolver</artifactId>
+                <scope>test</scope>
+                <version>${version.wildfly.glow}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 </project>

--- a/testsuite/layers-metadata-tests/pom.xml
+++ b/testsuite/layers-metadata-tests/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2020 Red Hat, Inc. and/or its affiliates
+    and other contributors as indicated by the @author tags.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss.resteasy.spring</groupId>
+        <artifactId>resteasy-spring-testsuite</artifactId>
+        <version>3.1.1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>galleon-feature-pack-layers-metadata-tests</artifactId>
+    <name>RESTEasy Galleon feature-pack layers metadata tests</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.glow</groupId>
+            <artifactId>wildfly-glow-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wildfly.glow</groupId>
+            <artifactId>wildfly-glow-maven-resolver</artifactId>
+            <scope>test</scope>
+        </dependency>
+     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-provisioning-xml</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.testOutputDirectory}/glow/${project.version}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/test/resources/glow/latest</directory>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <excludes>
+                    <exclude>wildfly-glow/latest/*</exclude>
+                </excludes>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
+    </build>
+</project>

--- a/testsuite/layers-metadata-tests/src/test/java/org/jboss/resteasy/galleon/pack/test/layers/metadata/AbstractLayerMetaDataTestCase.java
+++ b/testsuite/layers-metadata-tests/src/test/java/org/jboss/resteasy/galleon/pack/test/layers/metadata/AbstractLayerMetaDataTestCase.java
@@ -1,0 +1,73 @@
+package org.jboss.resteasy.galleon.pack.test.layers.metadata;
+
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.wildfly.glow.Arguments;
+import org.wildfly.glow.GlowMessageWriter;
+import org.wildfly.glow.GlowSession;
+import org.wildfly.glow.ScanResults;
+import org.wildfly.glow.maven.MavenResolver;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class AbstractLayerMetaDataTestCase {
+
+    private static String URL_PROPERTY = "wildfly-glow-galleon-feature-packs-url";
+    private static Path ARCHIVES_PATH = Paths.get("target/glow-archives");
+
+    @BeforeClass
+    public static void prepareArchivesDirectory() throws Exception {
+        Path glowXmlPath = Path.of("target/test-classes/glow");
+        System.setProperty(URL_PROPERTY, glowXmlPath.toUri().toString());
+        if (Files.exists(ARCHIVES_PATH)) {
+            Files.walkFileTree(ARCHIVES_PATH, new SimpleFileVisitor<>() {
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    Files.delete(file);
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    Files.delete(dir);
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        }
+        Files.createDirectories(ARCHIVES_PATH);
+    }
+
+
+    protected static Path createWebArchive(String archiveName, String xmlName, URL xmlContent) {
+        WebArchive war = ShrinkWrap.create(WebArchive.class);
+        war.addAsWebInfResource(xmlContent, xmlName);
+        ZipExporter exporter = war.as(ZipExporter.class);
+        Path path = ARCHIVES_PATH.resolve(archiveName);
+        exporter.exportTo(path.toFile());
+        return path;
+    }
+
+    protected Set<String> checkLayersForArchive(Path archivePath, String expectedLayer) throws Exception {
+        Arguments arguments = Arguments.scanBuilder().setBinaries(Collections.singletonList(archivePath)).build();
+        ScanResults scanResults = GlowSession.scan(MavenResolver.newMavenResolver(), arguments, GlowMessageWriter.DEFAULT);
+        Set<String> foundLayers = scanResults.getDiscoveredLayers().stream().map(l -> l.getName()).collect(Collectors.toSet());
+
+
+        Assert.assertTrue(foundLayers.contains(expectedLayer));
+
+        return foundLayers;
+    }
+}

--- a/testsuite/layers-metadata-tests/src/test/java/org/jboss/resteasy/galleon/pack/test/layers/metadata/ResteasySpringLayerMetaDataTestCase.java
+++ b/testsuite/layers-metadata-tests/src/test/java/org/jboss/resteasy/galleon/pack/test/layers/metadata/ResteasySpringLayerMetaDataTestCase.java
@@ -1,0 +1,20 @@
+package org.jboss.resteasy.galleon.pack.test.layers.metadata;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+public class ResteasySpringLayerMetaDataTestCase extends AbstractLayerMetaDataTestCase {
+    private static Path web;
+
+    @BeforeClass
+    public static void createArchives() {
+        web = createWebArchive("web.war", "web.xml", ResteasySpringLayerMetaDataTestCase.class.getResource("/web.xml"));
+    }
+
+    @Test
+    public void testWeb() throws Exception {
+        checkLayersForArchive(web, "resteasy-spring");
+    }
+}

--- a/testsuite/layers-metadata-tests/src/test/resources/glow/latest/provisioning-bare-metal.xml
+++ b/testsuite/layers-metadata-tests/src/test/resources/glow/latest/provisioning-bare-metal.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+
+<installation xmlns="urn:jboss:galleon:provisioning:3.0">
+    <feature-pack location="org.wildfly:wildfly-ee-galleon-pack:${version.org.wildfly}"/>
+    <feature-pack location="org.jboss.resteasy.spring:galleon-feature-pack:${project.version}"/>
+</installation>

--- a/testsuite/layers-metadata-tests/src/test/resources/glow/versions.yaml
+++ b/testsuite/layers-metadata-tests/src/test/resources/glow/versions.yaml
@@ -1,0 +1,2 @@
+latest: ${project.version}
+versions: ${project.version}

--- a/testsuite/layers-metadata-tests/src/test/resources/web.xml
+++ b/testsuite/layers-metadata-tests/src/test/resources/web.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.1"
+    xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/web-app_3_1.xsd"
+         metadata-complete="true">
+
+    <display-name>Archetype Created Web Application</display-name>
+
+    <listener>
+        <listener-class>org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap</listener-class>
+    </listener>
+
+    <listener>
+        <listener-class>org.jboss.resteasy.plugins.spring.SpringContextLoaderListener</listener-class>
+    </listener>
+
+    <servlet>
+        <servlet-name>resteasy-endpoint</servlet-name>
+        <servlet-class>org.jboss.resteasy.plugins.server.servlet.HttpServletDispatcher</servlet-class>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>resteasy-endpoint</servlet-name>
+        <url-pattern>/*</url-pattern>
+    </servlet-mapping>
+
+</web-app>

--- a/testsuite/pom.xml
+++ b/testsuite/pom.xml
@@ -18,6 +18,7 @@
         <module>shared</module>
         <module>integration-tests-spring</module>
         <module>integration-tests-spring-web</module>
+        <module>layers-metadata-tests</module>
     </modules>
 
     <properties>


### PR DESCRIPTION
* Introduce a resteasy-spring Galleon layer to allow to provision JBoss Modules modules for spring integration. 

* Integrate this feature-pack/layer with WildFly[ Glow tooling](https://github.com/wildfly/wildfly-glow)

* Galleon layer metadata rule added to the Galleon layer: A web.xml file containing an xml element /web-app/listener/listener-class with value org.jboss.resteasy.plugins.server.servlet.ResteasyBootstrap  is making the layer resteasy-spring to be provisioned.

* In order to have this feature-pack integrated in the WildFly 30.0.0.Final Galleon feature-packs registry: https://github.com/wildfly/wildfly-galleon-feature-packs/tree/release we would need a new release of this feature-pack once this PR is merged.
