### PR TITLE
Current upstream RESTEasy requires Java 21. Test WildFly upstream wit…

### DIFF
--- a/.github/workflows/resteasy-build.yml
+++ b/.github/workflows/resteasy-build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['17', '20']
+        java: ['21']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wildfly-build.yml
+++ b/.github/workflows/wildfly-build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['17', '20']
+        java: ['17', '21']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
…h Java 21 instead of 20.