### PR TITLE
CI Updates

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest ]
         java: ['17']
-        wildfly-version: ['27.0.1.Final', '28.0.1.Final']
+        wildfly-version: ['27.0.1.Final', '30.0.1.Final']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/resteasy-build.yml
+++ b/.github/workflows/resteasy-build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['17', '20']
+        java: ['17', '21']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/wildfly-build.yml
+++ b/.github/workflows/wildfly-build.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        java: ['17', '20']
+        java: ['17', '21']
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Update the testing with upstream jobs to use Java 21.

Change the 3.0 branch to test against the latest released WildFly keeping an older release for backwards compatibility testing.